### PR TITLE
Add username handling to lead pipeline

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     google_sheets_id: str = Field(alias="GOOGLE_SHEETS_ID")
     google_service_json_b64: str = Field(alias="GOOGLE_SERVICE_JSON_B64")
     port: int = Field(default=8000, alias="PORT")
+    leads_upsert: bool = Field(default=False, alias="LEADS_UPSERT")
 
     @field_validator("mode")
     @classmethod
@@ -48,6 +49,17 @@ class Settings(BaseSettings):
         if value in (None, "", 0, "0"):
             return None
         return int(value)
+
+    @field_validator("leads_upsert", mode="before")
+    @classmethod
+    def normalize_leads_upsert(cls, value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value in (None, ""):
+            return False
+        if isinstance(value, (int, float)):
+            return bool(value)
+        return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
     @cached_property
     def google_service_credentials(self) -> Dict[str, Any]:

--- a/app/handlers/contacts.py
+++ b/app/handlers/contacts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
-import logging
+from typing import Any
 
 from aiogram import Dispatcher, types
 from aiogram.dispatcher import FSMContext
@@ -10,7 +10,22 @@ from app.config import get_settings
 from app.keyboards.common import kb_send_contact
 from app.services import phone, sheets, stats
 
-logger = logging.getLogger(__name__)
+
+def _normalize_username(raw: str | None) -> str:
+    if not raw:
+        return ""
+    username = raw.strip().lstrip("@")
+    if not username:
+        return ""
+    return f"@{username.lower()}"
+
+
+def _values_equal(value: Any, expected: str) -> bool:
+    if value is None:
+        return expected == ""
+    if isinstance(value, float) and value.is_integer():
+        value = int(value)
+    return str(value) == expected
 
 
 async def handle_contact(message: types.Message, state: FSMContext) -> None:
@@ -18,7 +33,7 @@ async def handle_contact(message: types.Message, state: FSMContext) -> None:
         return
 
     data = await state.get_data()
-    campaign = data.get("campaign", "default")
+    campaign = str(data.get("campaign") or "default")
 
     if message.text and message.text.lower() == "отмена":
         await message.answer("Отменено.", reply_markup=types.ReplyKeyboardRemove())
@@ -39,26 +54,72 @@ async def handle_contact(message: types.Message, state: FSMContext) -> None:
         await message.answer("Не удалось распознать номер. Попробуй в формате +7XXXXXXXXXX.")
         return
 
-    await sheets.append(
-        "leads",
-        {
-            "user_id": message.from_user.id,
-            "phone": normalized,
-            "campaign": campaign,
-            "created_at": dt.datetime.utcnow().isoformat(),
-            "status": "new",
-        },
-    )
-    await stats.log_event(message.from_user.id, campaign, "lead", {"phone": normalized})
-
     settings = get_settings()
+    normalized_username = _normalize_username(message.from_user.username)
+    required_columns = ["username"]
+    if settings.leads_upsert:
+        required_columns.append("updated_at")
+    await sheets.ensure_columns("leads", required_columns)
+
+    now_iso = dt.datetime.utcnow().isoformat()
+    lead_row = {
+        "user_id": message.from_user.id,
+        "username": normalized_username,
+        "phone": normalized,
+        "campaign": campaign,
+        "created_at": now_iso,
+        "status": "new",
+    }
+
+    if settings.leads_upsert:
+        existing_leads = await sheets.read("leads")
+        target_row: int | None = None
+        for lead in existing_leads:
+            if _values_equal(lead.get("user_id"), str(message.from_user.id)) and _values_equal(
+                lead.get("campaign"), campaign
+            ):
+                target_row = int(lead.get("row")) if lead.get("row") is not None else None
+                break
+        if target_row:
+            await sheets.update_row(
+                "leads",
+                target_row,
+                {
+                    "phone": normalized,
+                    "username": normalized_username,
+                    "updated_at": now_iso,
+                },
+            )
+        else:
+            lead_row["updated_at"] = now_iso
+            await sheets.append("leads", lead_row)
+    else:
+        await sheets.append("leads", lead_row)
+
+    await stats.log_event(
+        message.from_user.id,
+        campaign,
+        "lead",
+        {"username": normalized_username},
+    )
+
     await message.answer("Спасибо! Мы свяжемся с тобой в ближайшее время.", reply_markup=types.ReplyKeyboardRemove())
     if settings.admin_chat_id:
-        username = message.from_user.username
-        user_ref = f"@{username}" if username else str(message.from_user.id)
+        if normalized_username:
+            user_ref = normalized_username
+            profile_link = f"https://t.me/{normalized_username.lstrip('@')}"
+        else:
+            user_ref = str(message.from_user.id)
+            profile_link = f"tg://user?id={message.from_user.id}"
         await message.bot.send_message(
             settings.admin_chat_id,
-            f"Новый лид {normalized} по кампании {campaign} от {user_ref}",
+            "\n".join(
+                [
+                    f"Новый лид {normalized} по кампании {campaign}",
+                    f"Пользователь: {user_ref}",
+                    f"Профиль: {profile_link}",
+                ]
+            ),
         )
 
 


### PR DESCRIPTION
## Summary
- normalize Telegram usernames, persist them to Google Sheets leads rows, analytics meta and admin alerts with proper links
- ensure the `leads` worksheet exposes a `username` column, optionally upserting rows when `LEADS_UPSERT=true`
- document the username workflow and new environment flag in the README

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d3e76397fc8320864aefcf9f13fb71