### PR TITLE
Add scheduled reminder flow for unclaimed coupons

### DIFF
--- a/app/handlers/contacts.py
+++ b/app/handlers/contacts.py
@@ -8,7 +8,8 @@ from aiogram.dispatcher import FSMContext
 
 from app.config import get_settings
 from app.keyboards.common import kb_send_contact
-from app.services import phone, sheets, stats
+from app.services import phone, reminders, sheets, stats
+from app.storage import db
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +92,8 @@ async def handle_contact(message: types.Message, state: FSMContext) -> None:
             "username": normalized_username,
         },
     )
+    await db.upsert_lead(message.from_user.id, campaign)
+    await reminders.cancel_due_to_lead(message.from_user.id, campaign)
     await message.answer("Спасибо! Мы свяжемся с тобой в ближайшее время.", reply_markup=types.ReplyKeyboardRemove())
     if settings.admin_chat_id:
         if normalized_username:

--- a/app/services/coupons.py
+++ b/app/services/coupons.py
@@ -47,5 +47,11 @@ async def get_user_coupon(user_id: int, campaign: str | None = None) -> Optional
         code = (record.get("code") or "").strip()
         if not code:
             continue
-        return {"row": record["row"], "code": code, "campaign": record_campaign}
+        return {
+            "row": record["row"],
+            "code": code,
+            "campaign": record_campaign,
+            "used_at": record.get("used_at"),
+            "status": record.get("status"),
+        }
     return None

--- a/app/services/reminders.py
+++ b/app/services/reminders.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from html import escape
+from typing import Dict, Optional
+
+from aiogram import Bot
+from aiogram.utils.exceptions import BotBlocked, ChatNotFound, RetryAfter, TelegramAPIError
+from zoneinfo import ZoneInfo
+
+from app.config import get_settings
+from app.keyboards.common import kb_after_coupon
+from app.services import coupons, stats
+from app.storage import db
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc)
+
+
+def _parse_datetime(value: str) -> dt.datetime:
+    try:
+        parsed = dt.datetime.fromisoformat(value)
+    except ValueError:
+        parsed = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+    else:
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        else:
+            parsed = parsed.astimezone(dt.timezone.utc)
+    return parsed
+
+
+@dataclass(frozen=True)
+class ReminderKey:
+    user_id: int
+    campaign: str
+
+
+class ReminderScheduler:
+    def __init__(self) -> None:
+        self._bot: Bot | None = None
+        self._tasks: Dict[ReminderKey, asyncio.Task[None]] = {}
+        self._lock = asyncio.Lock()
+        self._started = False
+
+    async def start(self, bot: Bot) -> None:
+        if self._started:
+            return
+        self._bot = bot
+        self._started = True
+        pending = await db.fetch_pending_reminders()
+        for item in pending:
+            await self._ensure_task(ReminderKey(item["user_id"], item["campaign"]))
+        if pending:
+            logger.info("Reminder scheduler restored %d pending reminders", len(pending))
+        else:
+            logger.info("Reminder scheduler started with no pending reminders")
+
+    async def stop(self) -> None:
+        if not self._started:
+            return
+        self._started = False
+        for task in list(self._tasks.values()):
+            task.cancel()
+        self._tasks.clear()
+        self._bot = None
+        logger.info("Reminder scheduler stopped")
+
+    async def schedule(self, user_id: int, campaign: str, code: Optional[str]) -> None:
+        settings = get_settings()
+        campaign = campaign or "default"
+
+        if settings.reminder_max_per_user == 0:
+            await stats.log_event(
+                user_id,
+                campaign,
+                "reminder_skipped",
+                {"reason": "limit_disabled"},
+            )
+            return
+
+        if not settings.reminder_enabled:
+            await stats.log_event(
+                user_id,
+                campaign,
+                "reminder_skipped",
+                {"reason": "disabled"},
+            )
+            return
+
+        if settings.reminder_only_if_no_lead and await db.has_lead(user_id, campaign):
+            await stats.log_event(
+                user_id,
+                campaign,
+                "reminder_skipped",
+                {"reason": "lead_exists"},
+            )
+            return
+
+        coupon_info = None
+        if settings.reminder_only_if_not_used or not code:
+            coupon_info = await coupons.get_user_coupon(user_id, campaign)
+        if coupon_info:
+            code = code or coupon_info.get("code")
+        if not code:
+            await stats.log_event(
+                user_id,
+                campaign,
+                "reminder_skipped",
+                {"reason": "no_code"},
+            )
+            return
+
+        if settings.reminder_only_if_not_used:
+            used_at = ""
+            if coupon_info is None:
+                coupon_info = await coupons.get_user_coupon(user_id, campaign)
+            if coupon_info:
+                used_at = str(coupon_info.get("used_at") or "").strip()
+            if used_at:
+                await stats.log_event(
+                    user_id,
+                    campaign,
+                    "reminder_skipped",
+                    {"reason": "coupon_used", "used_at": used_at},
+                )
+                return
+
+        existing = await db.get_reminder(user_id, campaign)
+        if existing:
+            attempts = int(existing.get("attempts") or 0)
+            if attempts >= settings.reminder_max_per_user:
+                await stats.log_event(
+                    user_id,
+                    campaign,
+                    "reminder_skipped",
+                    {"reason": "attempt_limit", "attempts": attempts},
+                )
+                return
+            status = (existing.get("status") or "").strip().lower()
+            if status == "scheduled":
+                await stats.log_event(
+                    user_id,
+                    campaign,
+                    "reminder_skipped",
+                    {"reason": "already_scheduled", "attempts": attempts},
+                )
+                return
+            if status in {"sent", "cancelled"}:
+                await stats.log_event(
+                    user_id,
+                    campaign,
+                    "reminder_skipped",
+                    {"reason": f"already_{status}", "attempts": attempts},
+                )
+                return
+            attempts = attempts + 1
+        else:
+            attempts = 1
+
+        base_time = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc) + dt.timedelta(
+            hours=settings.reminder_delay_hours
+        )
+        scheduled_at = self._adjust_to_work_hours(base_time)
+
+        await db.upsert_reminder(
+            user_id,
+            campaign,
+            code,
+            scheduled_at.isoformat(),
+            attempts,
+            status="scheduled",
+            reason="",
+        )
+        await stats.log_event(
+            user_id,
+            campaign,
+            "reminder_scheduled",
+            {"scheduled_at": scheduled_at.isoformat(), "code": code, "attempt": attempts},
+        )
+
+        if self._started and self._bot:
+            await self._ensure_task(ReminderKey(user_id, campaign))
+
+    async def cancel(self, user_id: int, campaign: str, reason: str) -> bool:
+        campaign = campaign or "default"
+        reminder = await db.get_reminder(user_id, campaign)
+        if not reminder or (reminder.get("status") or "").lower() != "scheduled":
+            return False
+        cancelled_at = dt.datetime.utcnow().isoformat()
+        await db.update_reminder(
+            user_id,
+            campaign,
+            status="cancelled",
+            reason=reason,
+            cancelled_at=cancelled_at,
+        )
+        await stats.log_event(
+            user_id,
+            campaign,
+            "reminder_cancelled",
+            {"reason": reason, "cancelled_at": cancelled_at},
+        )
+        key = ReminderKey(user_id, campaign)
+        async with self._lock:
+            task = self._tasks.pop(key, None)
+            if task:
+                task.cancel()
+        return True
+
+    async def _ensure_task(self, key: ReminderKey) -> None:
+        async with self._lock:
+            task = self._tasks.get(key)
+            if task and not task.done():
+                return
+            loop = asyncio.get_running_loop()
+            task = loop.create_task(self._run_reminder(key))
+            self._tasks[key] = task
+            task.add_done_callback(lambda t, *, key=key: self._tasks.pop(key, None))
+
+    def _adjust_to_work_hours(self, target: dt.datetime) -> dt.datetime:
+        settings = get_settings()
+        try:
+            tz = ZoneInfo(settings.reminder_timezone)
+        except Exception:
+            logger.warning("Unknown timezone %s, falling back to UTC", settings.reminder_timezone)
+            tz = ZoneInfo("UTC")
+        target_utc = _ensure_utc(target)
+        local_time = target_utc.astimezone(tz)
+        start_hour, end_hour = settings.reminder_work_hours
+        start_local = local_time.replace(hour=start_hour, minute=0, second=0, microsecond=0)
+        end_local = local_time.replace(hour=end_hour, minute=0, second=0, microsecond=0)
+
+        if local_time < start_local:
+            return start_local.astimezone(dt.timezone.utc)
+        if local_time >= end_local:
+            next_day = start_local + dt.timedelta(days=1)
+            return next_day.astimezone(dt.timezone.utc)
+        return target_utc
+
+    async def _run_reminder(self, key: ReminderKey) -> None:
+        try:
+            while self._started:
+                reminder = await db.get_reminder(key.user_id, key.campaign)
+                if not reminder or (reminder.get("status") or "").lower() != "scheduled":
+                    return
+
+                scheduled_at = _parse_datetime(str(reminder.get("scheduled_at")))
+                now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+                if scheduled_at > now:
+                    await asyncio.sleep((scheduled_at - now).total_seconds())
+                    continue
+
+                ready_at = self._adjust_to_work_hours(now)
+                if ready_at > now:
+                    await db.update_reminder(
+                        key.user_id,
+                        key.campaign,
+                        scheduled_at=ready_at.isoformat(),
+                    )
+                    await asyncio.sleep((ready_at - now).total_seconds())
+                    continue
+
+                settings = get_settings()
+                if settings.reminder_only_if_no_lead and await db.has_lead(key.user_id, key.campaign):
+                    await self._mark_cancelled(key, "lead")
+                    return
+
+                coupon_info = await coupons.get_user_coupon(key.user_id, key.campaign)
+                if not coupon_info:
+                    await self._mark_cancelled(key, "no_coupon")
+                    return
+
+                used_at = str(coupon_info.get("used_at") or "").strip()
+                if settings.reminder_only_if_not_used and used_at:
+                    await self._mark_cancelled(key, "coupon_used", {"used_at": used_at})
+                    return
+
+                code = str(reminder.get("code") or coupon_info.get("code") or "").strip()
+                if not code:
+                    await self._mark_cancelled(key, "no_code")
+                    return
+
+                bot = self._bot
+                if bot is None:
+                    logger.warning("Bot instance missing, postponing reminder for %s/%s", key.user_id, key.campaign)
+                    await asyncio.sleep(5)
+                    continue
+
+                await self._send_reminder(bot, key, code)
+                return
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Reminder task crashed for %s/%s", key.user_id, key.campaign)
+            await self._mark_cancelled(key, "error")
+
+    async def _send_reminder(self, bot: Bot, key: ReminderKey, code: str) -> None:
+        payload = {
+            "code": escape(code),
+            "code_plain": code,
+        }
+        settings = get_settings()
+        text_template = settings.reminder_text or "Не забудь воспользоваться подарком!"
+        try:
+            text = text_template.format(**payload)
+        except Exception:
+            text = text_template
+
+        try:
+            await bot.send_message(
+                key.user_id,
+                text,
+                reply_markup=kb_after_coupon(key.campaign),
+            )
+        except (BotBlocked, ChatNotFound):
+            await self._mark_cancelled(key, "unreachable")
+            return
+        except RetryAfter as exc:
+            delay = int(getattr(exc, "timeout", 5))
+            logger.warning(
+                "RetryAfter while sending reminder to %s/%s, sleeping %s s",
+                key.user_id,
+                key.campaign,
+                delay,
+            )
+            await asyncio.sleep(delay)
+            await self._send_reminder(bot, key, code)
+            return
+        except TelegramAPIError:
+            logger.exception("Telegram API error when sending reminder to %s/%s", key.user_id, key.campaign)
+            await self._mark_cancelled(key, "send_failed")
+            return
+
+        sent_at = dt.datetime.utcnow().isoformat()
+        await db.update_reminder(
+            key.user_id,
+            key.campaign,
+            status="sent",
+            sent_at=sent_at,
+            reason="",
+        )
+        await stats.log_event(
+            key.user_id,
+            key.campaign,
+            "reminder_sent",
+            {"code": code, "sent_at": sent_at},
+        )
+
+    async def _mark_cancelled(
+        self,
+        key: ReminderKey,
+        reason: str,
+        extra_meta: Optional[Dict[str, str]] = None,
+    ) -> None:
+        reminder = await db.get_reminder(key.user_id, key.campaign)
+        if not reminder or (reminder.get("status") or "").lower() != "scheduled":
+            return
+        cancelled_at = dt.datetime.utcnow().isoformat()
+        await db.update_reminder(
+            key.user_id,
+            key.campaign,
+            status="cancelled",
+            reason=reason,
+            cancelled_at=cancelled_at,
+        )
+        meta = {"reason": reason, "cancelled_at": cancelled_at}
+        if extra_meta:
+            meta.update(extra_meta)
+        await stats.log_event(key.user_id, key.campaign, "reminder_cancelled", meta)
+
+
+_scheduler = ReminderScheduler()
+
+
+async def on_startup(bot: Bot) -> None:
+    await _scheduler.start(bot)
+
+
+async def on_shutdown() -> None:
+    await _scheduler.stop()
+
+
+async def schedule_reminder(user_id: int, campaign: str, code: Optional[str]) -> None:
+    await _scheduler.schedule(user_id, campaign, code)
+
+
+async def cancel_due_to_lead(user_id: int, campaign: str) -> bool:
+    return await _scheduler.cancel(user_id, campaign, "lead")

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import datetime as dt
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 import aiosqlite
 
@@ -22,6 +22,34 @@ async def init_db() -> None:
                 campaign TEXT NOT NULL,
                 code TEXT NOT NULL,
                 ts TEXT NOT NULL,
+                PRIMARY KEY(user_id, campaign)
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reminders (
+                user_id INTEGER NOT NULL,
+                campaign TEXT NOT NULL,
+                code TEXT,
+                scheduled_at TEXT NOT NULL,
+                status TEXT NOT NULL,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                sent_at TEXT,
+                cancelled_at TEXT,
+                reason TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY(user_id, campaign)
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS leads (
+                user_id INTEGER NOT NULL,
+                campaign TEXT NOT NULL,
+                created_at TEXT NOT NULL,
                 PRIMARY KEY(user_id, campaign)
             )
             """
@@ -51,3 +79,148 @@ async def insert_coupon(user_id: int, campaign: str, code: str) -> None:
             (user_id, campaign, code, dt.datetime.utcnow().isoformat()),
         )
         await db.commit()
+
+
+async def upsert_lead(user_id: int, campaign: str) -> None:
+    await init_db()
+    async with aiosqlite.connect(_db_file) as db:
+        await db.execute(
+            "INSERT OR REPLACE INTO leads(user_id, campaign, created_at) VALUES(?,?,?)",
+            (user_id, campaign, dt.datetime.utcnow().isoformat()),
+        )
+        await db.commit()
+
+
+async def has_lead(user_id: int, campaign: str) -> bool:
+    await init_db()
+    async with aiosqlite.connect(_db_file) as db:
+        cursor = await db.execute(
+            "SELECT 1 FROM leads WHERE user_id=? AND campaign=? LIMIT 1",
+            (user_id, campaign),
+        )
+        row = await cursor.fetchone()
+        await cursor.close()
+        return row is not None
+
+
+async def get_reminder(user_id: int, campaign: str) -> Optional[Dict[str, Any]]:
+    await init_db()
+    async with aiosqlite.connect(_db_file) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT user_id, campaign, code, scheduled_at, status, attempts, sent_at, cancelled_at, reason "
+            "FROM reminders WHERE user_id=? AND campaign=?",
+            (user_id, campaign),
+        )
+        row = await cursor.fetchone()
+        await cursor.close()
+        if row is None:
+            return None
+        return dict(row)
+
+
+async def upsert_reminder(
+    user_id: int,
+    campaign: str,
+    code: str,
+    scheduled_at: str,
+    attempts: int,
+    status: str = "scheduled",
+    reason: str | None = None,
+) -> None:
+    await init_db()
+    async with aiosqlite.connect(_db_file) as db:
+        now = dt.datetime.utcnow().isoformat()
+        await db.execute(
+            """
+            INSERT INTO reminders(
+                user_id,
+                campaign,
+                code,
+                scheduled_at,
+                status,
+                attempts,
+                reason,
+                created_at,
+                updated_at
+            ) VALUES(?,?,?,?,?,?,?,?,?)
+            ON CONFLICT(user_id, campaign) DO UPDATE SET
+                code=excluded.code,
+                scheduled_at=excluded.scheduled_at,
+                status=excluded.status,
+                attempts=excluded.attempts,
+                reason=excluded.reason,
+                updated_at=excluded.updated_at
+            """,
+            (
+                user_id,
+                campaign,
+                code,
+                scheduled_at,
+                status,
+                attempts,
+                reason or "",
+                now,
+                now,
+            ),
+        )
+        await db.commit()
+
+
+async def update_reminder(
+    user_id: int,
+    campaign: str,
+    *,
+    status: str | None = None,
+    scheduled_at: str | None = None,
+    attempts: int | None = None,
+    reason: str | None = None,
+    sent_at: str | None = None,
+    cancelled_at: str | None = None,
+) -> None:
+    await init_db()
+    fields: List[str] = []
+    values: List[Any] = []
+    if status is not None:
+        fields.append("status=?")
+        values.append(status)
+    if scheduled_at is not None:
+        fields.append("scheduled_at=?")
+        values.append(scheduled_at)
+    if attempts is not None:
+        fields.append("attempts=?")
+        values.append(attempts)
+    if reason is not None:
+        fields.append("reason=?")
+        values.append(reason)
+    if sent_at is not None:
+        fields.append("sent_at=?")
+        values.append(sent_at)
+    if cancelled_at is not None:
+        fields.append("cancelled_at=?")
+        values.append(cancelled_at)
+    if not fields:
+        return
+    fields.append("updated_at=?")
+    values.append(dt.datetime.utcnow().isoformat())
+    values.extend([user_id, campaign])
+
+    async with aiosqlite.connect(_db_file) as db:
+        await db.execute(
+            f"UPDATE reminders SET {', '.join(fields)} WHERE user_id=? AND campaign=?",
+            values,
+        )
+        await db.commit()
+
+
+async def fetch_pending_reminders() -> List[Dict[str, Any]]:
+    await init_db()
+    async with aiosqlite.connect(_db_file) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT user_id, campaign, code, scheduled_at, attempts FROM reminders WHERE status=?",
+            ("scheduled",),
+        )
+        rows = await cursor.fetchall()
+        await cursor.close()
+        return [dict(row) for row in rows]


### PR DESCRIPTION
## Summary
- add configurable reminder settings and local persistence for coupon reminders
- implement async reminder scheduler with work-hour delivery, cancellation rules, and analytics events
- hook scheduler into gift and lead flows plus FastAPI/aiogram lifecycles

## Testing
- `python -m compileall app`


------
https://chatgpt.com/codex/tasks/task_e_68d3f2949ca0832080a830080a91ab59