### PR TITLE
Add lottery entrypoints and analytics

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -51,6 +51,9 @@ class Settings(BaseSettings):
     lottery_cooldown_days: int = Field(default=1, alias="LOTTERY_COOLDOWN_DAYS")
     lottery_title: str = Field(default="Выбирай окно 🎁", alias="LOTTERY_TITLE")
     lottery_button_emoji: str = Field(default="🎯", alias="LOTTERY_BUTTON_EMOJI")
+    lottery_button_label: str = Field(default="🎲 Лотерея", alias="LOTTERY_BTN_LABEL")
+    draw_prefix: str = Field(default="draw_", alias="DRAW_PREFIX")
+    lottery_ab_test: bool = Field(default=False, alias="LOTTERY_A_B_TEST")
 
     alerts_enabled: bool = Field(default=False, alias="ALERTS_ENABLED")
     alerts_mention: str | None = Field(default=None, alias="ALERTS_MENTION")
@@ -141,6 +144,11 @@ class Settings(BaseSettings):
     @field_validator("lottery_enabled", mode="before")
     @classmethod
     def parse_lottery_enabled(cls, value: Any) -> bool:
+        return cls._parse_bool(value)
+
+    @field_validator("lottery_ab_test", mode="before")
+    @classmethod
+    def parse_lottery_ab_test(cls, value: Any) -> bool:
         return cls._parse_bool(value)
 
     @field_validator("alerts_rate_limit")
@@ -257,6 +265,12 @@ class Settings(BaseSettings):
     @classmethod
     def validate_lottery_cooldown(cls, value: int) -> int:
         return max(0, value)
+
+    @field_validator("draw_prefix")
+    @classmethod
+    def normalize_draw_prefix(cls, value: str) -> str:
+        prefix = (value or "").strip()
+        return prefix or "draw_"
 
     @cached_property
     def google_service_credentials(self) -> Dict[str, Any]:

--- a/app/handlers/fun_interactive.py
+++ b/app/handlers/fun_interactive.py
@@ -21,7 +21,14 @@ async def cmd_fortune(message: types.Message, state: FSMContext) -> None:
     campaign = parse_start_payload(message.text)
     await state.update_data(campaign=campaign)
     fortune = random.choice(FORTUNES)
-    await stats.log_event(message.from_user.id, campaign, "fortune", {"fortune": fortune})
+    username = message.from_user.username if message.from_user else None
+    await stats.log_event(
+        message.from_user.id,
+        campaign,
+        "fortune",
+        {"fortune": fortune},
+        username=username,
+    )
     await message.answer(
         f"🔮 {fortune}\nГотов забрать подарок?",
         reply_markup=kb_get_gift(campaign),

--- a/app/services/stats.py
+++ b/app/services/stats.py
@@ -7,14 +7,26 @@ from typing import Any, Dict
 from app.services import sheets
 
 
-async def log_event(user_id: int, campaign: str, step: str, meta: Dict[str, Any] | None = None) -> None:
-    if meta is None:
-        meta = {}
+async def log_event(
+    user_id: int,
+    campaign: str,
+    step: str,
+    meta: Dict[str, Any] | None = None,
+    *,
+    username: str | None = None,
+) -> None:
+    meta_payload: Dict[str, Any] = {}
+    if meta:
+        meta_payload.update(meta)
+    meta_payload.setdefault("user_id", user_id)
+    meta_payload.setdefault("campaign", campaign or "default")
+    if username:
+        meta_payload.setdefault("username", username)
     data = {
         "ts": dt.datetime.utcnow().isoformat(),
         "user_id": user_id,
         "campaign": campaign or "default",
         "step": step,
-        "meta_json": json.dumps(meta, ensure_ascii=False),
+        "meta_json": json.dumps(meta_payload, ensure_ascii=False),
     }
     await sheets.append("events", data)


### PR DESCRIPTION
## Summary
- add configuration for lottery entry button label, deep-link prefix, and A/B test control
- extend /start flow with lottery button handling, deep-link auto launch, and enriched analytics
- enhance lottery handlers to enforce cooldown messaging, source-specific logging, and weighted result reporting

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d402691de08320afa25135f7112231