### PR TITLE
Add Moscow time columns when writing to Google Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ MVP Telegram-бот для образовательных кампаний. По
 | `CHANNEL_USERNAME` | Username канала (с `@`), на который проверяется подписка. |
 | `GOOGLE_SHEETS_ID` | Идентификатор Google Sheets (часть URL между `/d/` и `/edit`). |
 | `GOOGLE_SERVICE_JSON_B64` | base64-строка от JSON-ключа сервисного аккаунта. |
+| `SHEETS_TZ` | Таймзона (IANA) для локализованного времени в Google Sheets. По умолчанию `Europe/Moscow`. |
+| `SHEETS_TIME_FORMAT` | Формат отображения локального времени (`strftime`). По умолчанию `%Y-%m-%d %H:%M:%S`. |
 | `PORT` | Порт HTTP-сервера FastAPI (актуально в режиме webhook). |
 | `LEADS_UPSERT` | `true/false`. При `true` обновляет лид по паре `(user_id, campaign)` вместо добавления новой строки. |
 | `ALERTS_ENABLED` | `true/false`. Глобальный флаг отправки алёртов. |
@@ -51,9 +53,9 @@ MVP Telegram-бот для образовательных кампаний. По
 
 | Лист | Поля |
 | --- | --- |
-| `coupons` | `code`, `campaign`, `status`, `reserved_by`, `reserved_at`, `used_at`. Статус свободного купона — `free` или пустой. |
-| `leads` | `user_id`, `username`, `phone`, `campaign`, `created_at`, `status`, `updated_at` (опционально). |
-| `events` | `user_id`, `campaign`, `step`, `ts`, `meta_json`. |
+| `coupons` | `code`, `campaign`, `status`, `reserved_by`, `reserved_at`, `reserved_at_msk` (опц.), `used_at`, `used_at_msk` (опц.). Статус свободного купона — `free` или пустой. |
+| `leads` | `user_id`, `username`, `phone`, `campaign`, `created_at`, `created_at_msk` (опц.), `status`, `updated_at` (опционально). |
+| `events` | `user_id`, `campaign`, `step`, `ts`, `ts_msk` (опц.), `meta_json`. |
 
 ## Запуск и режимы
 
@@ -108,6 +110,7 @@ app/
 5. `/fortune <campaign>` — выдаёт предсказание, логирует `fortune`, показывает CTA на подарок.
 6. `MODE=webhook`: при запуске устанавливается webhook (`/tg/webhook` проверяет секрет), `/health` возвращает `{"ok": true}`. После тестов верните `MODE=polling`, чтобы удалить webhook.
 7. При исчерпании купонов пользователь видит корректное сообщение, а в `events` фиксируется `no_coupons` и админу отправляется алёрт.
+8. Создайте тестовую запись в таблице (лид, событие или резерв купона) и убедитесь, что рядом с UTC-полем появилась колонка `*_msk` с временем в формате `%Y-%m-%d %H:%M:%S`.
 
 ## Troubleshooting
 

--- a/app/config.py
+++ b/app/config.py
@@ -24,6 +24,10 @@ class Settings(BaseSettings):
     channel_username: str = Field(alias="CHANNEL_USERNAME")
     google_sheets_id: str = Field(alias="GOOGLE_SHEETS_ID")
     google_service_json_b64: str = Field(alias="GOOGLE_SERVICE_JSON_B64")
+    sheets_tz: str = Field(default="Europe/Moscow", alias="SHEETS_TZ")
+    sheets_time_format: str = Field(
+        default="%Y-%m-%d %H:%M:%S", alias="SHEETS_TIME_FORMAT"
+    )
     port: int = Field(default=8000, alias="PORT")
     leads_upsert: bool = Field(default=False, alias="LEADS_UPSERT")
     reminder_enabled: bool = Field(default=False, alias="REMINDER_ENABLED")

--- a/app/services/coupons.py
+++ b/app/services/coupons.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime as dt
 from typing import Dict, Optional
 
 from app.services import sheets
@@ -28,13 +27,21 @@ async def find_first_free_coupon(campaign: str | None) -> Optional[Dict[str, str
 
 async def reserve_coupon(row: int, user_id: int, code: str) -> Dict[str, str]:
     sanitized_code = safe_text(code)
+    timestamp = sheets.current_timestamp()
     data = {
         "code": sanitized_code,
         "status": "reserved",
         "reserved_by": safe_text(user_id),
-        "reserved_at": dt.datetime.utcnow().isoformat(),
+        "reserved_at": timestamp.utc_text,
+        "reserved_at_msk": timestamp.local_text,
     }
-    await sheets.update_row(COUPONS_SHEET, row, data)
+    await sheets.update_row(
+        COUPONS_SHEET,
+        row,
+        data,
+        optional_headers=["reserved_at_msk"],
+        meta=timestamp.meta,
+    )
     return {"code": sanitized_code, "row": row}
 
 

--- a/app/services/stats.py
+++ b/app/services/stats.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime as dt
 import json
 from typing import Any, Dict
 
@@ -22,11 +21,15 @@ async def log_event(
     meta_payload.setdefault("campaign", campaign or "default")
     if username:
         meta_payload.setdefault("username", username)
+    timestamp = sheets.current_timestamp()
     data = {
-        "ts": dt.datetime.utcnow().isoformat(),
+        "ts": timestamp.utc_text,
+        "ts_msk": timestamp.local_text,
         "user_id": user_id,
         "campaign": campaign or "default",
         "step": step,
         "meta_json": json.dumps(meta_payload, ensure_ascii=False),
     }
-    await sheets.append("events", data)
+    await sheets.append(
+        "events", data, optional_headers=["ts_msk"], meta=timestamp.meta
+    )


### PR DESCRIPTION
## Summary
- add configurable sheet timezone/format and helper that returns UTC ISO and localized timestamps
- extend sheet append/update helpers to respect optional *_msk columns, log timestamp meta, and avoid creating missing columns automatically
- write Moscow time values for leads, events, and coupon reservations while documenting new columns and env settings

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d4e012b3e48320b06345e07cc4efc5