### PR TITLE
Move contact and intensive actions to reply keyboard

### DIFF
--- a/app/handlers/contacts.py
+++ b/app/handlers/contacts.py
@@ -8,7 +8,7 @@ from aiogram.dispatcher import FSMContext
 
 from app.config import get_settings
 from app.handlers import intensive as intensive_handlers
-from app.keyboards.common import kb_send_contact
+from app.keyboards.common import kb_main_menu, kb_send_contact
 from app.services import alerts, phone, reminders, sheets, stats
 from app.storage import db
 
@@ -34,6 +34,10 @@ async def handle_contact(message: types.Message, state: FSMContext) -> None:
     if message.text and message.text.lower() == "отмена":
         await message.answer("Отменено.", reply_markup=types.ReplyKeyboardRemove())
         await state.update_data(lead_context=None)
+        await message.answer(
+            "Хорошо, действия доступны на клавиатуре ниже.",
+            reply_markup=kb_main_menu(),
+        )
         return
 
     contact_phone: str | None = None
@@ -124,6 +128,10 @@ async def handle_contact(message: types.Message, state: FSMContext) -> None:
     await message.answer(
         "Спасибо! Мы свяжемся с тобой в ближайшее время.",
         reply_markup=types.ReplyKeyboardRemove(),
+    )
+    await message.answer(
+        "Если понадобится, воспользуйся клавиатурой ниже.",
+        reply_markup=kb_main_menu(),
     )
     await alerts.notify_new_lead(
         message.bot,

--- a/app/keyboards/common.py
+++ b/app/keyboards/common.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, KeyboardButton, ReplyKeyboardMarkup
+from aiogram.types import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    KeyboardButton,
+    ReplyKeyboardMarkup,
+)
 
 
 def kb_subscribe(url: str) -> InlineKeyboardMarkup:
@@ -18,14 +23,18 @@ def kb_check_sub(campaign: str) -> InlineKeyboardMarkup:
 def kb_get_gift(campaign: str) -> InlineKeyboardMarkup:
     kb = InlineKeyboardMarkup(row_width=1)
     kb.add(InlineKeyboardButton(text="🎁 Забрать подарок", callback_data=f"get_gift:{campaign}"))
-    kb.add(InlineKeyboardButton(text="📞 Оставить контакт", callback_data=f"leave_phone:{campaign}"))
     return kb
 
 
-def kb_after_coupon(campaign: str) -> InlineKeyboardMarkup:
-    kb = InlineKeyboardMarkup(row_width=1)
-    kb.add(InlineKeyboardButton(text="📞 Оставить контакт", callback_data=f"leave_phone:{campaign}"))
+def kb_main_menu() -> ReplyKeyboardMarkup:
+    kb = ReplyKeyboardMarkup(resize_keyboard=True)
+    kb.add(KeyboardButton(text="📞 Оставить контакт"))
+    kb.add(KeyboardButton(text="🥐 Производственный интенсив"))
     return kb
+
+
+def kb_after_coupon(campaign: str) -> ReplyKeyboardMarkup:
+    return kb_main_menu()
 
 
 def kb_send_contact() -> ReplyKeyboardMarkup:


### PR DESCRIPTION
## Summary
- move the contact and intensive actions from the inline start keyboard into a persistent reply keyboard
- add handlers that open the contact flow or intensive flow when the new reply buttons are pressed
- restore the main menu keyboard after cancelling or completing the contact flow and reuse it after coupons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df99f4a7248320929d68c8b01024e2