### PR TITLE
Add schedule photo for intensive QA topic

### DIFF
--- a/app/handlers/intensive.py
+++ b/app/handlers/intensive.py
@@ -124,6 +124,7 @@ TOPIC_BY_KEY: Dict[str, QATopic] = {topic.key: topic for topic in TOPICS}
 MEDIA_DIR = Path(__file__).resolve().parents[2]
 
 TOPIC_PHOTOS: Dict[str, Path] = {
+    "schedule": MEDIA_DIR / "14.jpg",
     "certificate": MEDIA_DIR / "11.png.webp",
     "included": MEDIA_DIR / "10.jpg.webp",
     "speakers": MEDIA_DIR / "9.jpg.webp",


### PR DESCRIPTION
## Summary
- display the new 14.jpg image when users open the "📅 Расписание" topic in the intensive flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbea888988320a9063bf2d42151e1