### PR TITLE
Disable QA topic photos for intensive responses

### DIFF
--- a/app/handlers/intensive.py
+++ b/app/handlers/intensive.py
@@ -116,10 +116,7 @@ TOPIC_BY_KEY: Dict[str, QATopic] = {topic.key: topic for topic in TOPICS}
 
 MEDIA_DIR = Path(__file__).resolve().parents[2]
 
-TOPIC_PHOTOS: Dict[str, Path] = {
-    "speakers": MEDIA_DIR / "9.jpg.webp",
-    "program": MEDIA_DIR / "12.jpg",
-}
+TOPIC_PHOTOS: Dict[str, Path] = {}
 
 
 def _topics_for_keyboard() -> list[tuple[str, str]]:


### PR DESCRIPTION
### Motivation
- Disable photo attachments for Q&A topics so intensive responses deliver text-only messages; changed `app/handlers/intensive.py` (grepable ids: `TOPIC_PHOTOS`, `_send_topic_answer`).

### Description
- Set `TOPIC_PHOTOS` to an empty dict in `app/handlers/intensive.py` so `_photo_for_topic` returns `None` and `_send_topic_answer` falls back to sending text-only answers.

### Testing
- Ran `python -m compileall app` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fb978e988320ac27cba8ea88971c)