### PR TITLE
Add admin username support for admin panel access

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ MVP Telegram-бот для образовательных кампаний. По
 | `MODE` | `polling` (по умолчанию) или `webhook`. |
 | `WEBHOOK_URL` | Публичный HTTPS-адрес приложения. Используется только в режиме webhook. |
 | `SECRET_TOKEN` | Значение заголовка `X-Telegram-Bot-Api-Secret-Token` для верификации запросов Telegram. |
-| `ADMIN_CHAT_ID` | Chat ID для админ-алёртов. Можно указать несколько через запятую (`служебный_чат,личный_ID`) для fallback. |
+| `ADMIN_CHAT_ID` | Chat ID или @username для админ-алёртов. Можно указать несколько через запятую (`служебный_чат,личный_ID,@admin`) для fallback. |
 | `CHANNEL_USERNAME` | Username канала (с `@`), на который проверяется подписка. |
 | `GOOGLE_SHEETS_ID` | Идентификатор Google Sheets (часть URL между `/d/` и `/edit`). |
 | `GOOGLE_SERVICE_JSON_B64` | base64-строка от JSON-ключа сервисного аккаунта. |
@@ -48,7 +48,7 @@ MVP Telegram-бот для образовательных кампаний. По
 | `QA_UNKNOWN_ANSWER` | Кастомный текст ответа при неизвестной теме. |
 | `QA_RATE_LIMIT_SECONDS` | Минимальный интервал между ответами одному пользователю (секунды). |
 
-> `ADMIN_CHAT_ID` можно узнать через @userinfobot или @RawDataBot — отправьте /start и используйте отображённый `id`.
+> `ADMIN_CHAT_ID` можно узнать через @userinfobot или @RawDataBot — отправьте /start и используйте отображённый `id`. При использовании username указывайте без пробелов (с `@` или без). 
 
 ### Что такое `campaign`
 

--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -15,13 +15,13 @@ class AdminCouponStates(StatesGroup):
 
 
 async def cmd_ping(message: types.Message) -> None:
-    if not is_admin_user(message.from_user.id):
+    if not is_admin_user(message.from_user.id, message.from_user.username):
         return
     await message.answer("pong")
 
 
 async def cmd_report(message: types.Message) -> None:
-    if not is_admin_user(message.from_user.id):
+    if not is_admin_user(message.from_user.id, message.from_user.username):
         return
     events = await sheets.read("events")
     leads = await sheets.read("leads")
@@ -47,21 +47,21 @@ def _admin_panel_kb() -> types.InlineKeyboardMarkup:
 
 
 async def cmd_admin(message: types.Message, state: FSMContext) -> None:
-    if not is_admin_user(message.from_user.id):
+    if not is_admin_user(message.from_user.id, message.from_user.username):
         return
     await state.finish()
     await message.answer("Админ-панель:", reply_markup=_admin_panel_kb())
 
 
 async def cmd_cancel(message: types.Message, state: FSMContext) -> None:
-    if not is_admin_user(message.from_user.id):
+    if not is_admin_user(message.from_user.id, message.from_user.username):
         return
     await state.finish()
     await message.answer("Действие отменено.", reply_markup=_admin_panel_kb())
 
 
 async def callback_admin_report(call: types.CallbackQuery) -> None:
-    if not is_admin_user(call.from_user.id):
+    if not is_admin_user(call.from_user.id, call.from_user.username):
         await call.answer()
         return
     await call.answer()
@@ -69,7 +69,7 @@ async def callback_admin_report(call: types.CallbackQuery) -> None:
 
 
 async def callback_admin_add_coupon(call: types.CallbackQuery, state: FSMContext) -> None:
-    if not is_admin_user(call.from_user.id):
+    if not is_admin_user(call.from_user.id, call.from_user.username):
         await call.answer()
         return
     await call.answer()
@@ -81,7 +81,7 @@ async def callback_admin_add_coupon(call: types.CallbackQuery, state: FSMContext
 
 
 async def message_admin_coupon_code(message: types.Message, state: FSMContext) -> None:
-    if not is_admin_user(message.from_user.id):
+    if not is_admin_user(message.from_user.id, message.from_user.username):
         return
     if not message.text:
         await message.answer("Пришлите текстовый код купона.")
@@ -98,7 +98,7 @@ async def message_admin_coupon_code(message: types.Message, state: FSMContext) -
 
 
 async def message_admin_coupon_campaign(message: types.Message, state: FSMContext) -> None:
-    if not is_admin_user(message.from_user.id):
+    if not is_admin_user(message.from_user.id, message.from_user.username):
         return
     if not message.text:
         await message.answer("Пришлите кампанию текстом или «-».")

--- a/app/handlers/contacts.py
+++ b/app/handlers/contacts.py
@@ -36,7 +36,7 @@ async def handle_contact(message: types.Message, state: FSMContext) -> None:
         await state.update_data(lead_context=None)
         await message.answer(
             "Хорошо, действия доступны на клавиатуре ниже.",
-            reply_markup=kb_main_menu(message.from_user.id),
+            reply_markup=kb_main_menu(message.from_user.id, message.from_user.username),
         )
         return
 
@@ -133,7 +133,7 @@ async def handle_contact(message: types.Message, state: FSMContext) -> None:
     )
     await message.answer(
         "Если понадобится, воспользуйтесь клавиатурой ниже.",
-        reply_markup=kb_main_menu(message.from_user.id),
+        reply_markup=kb_main_menu(message.from_user.id, message.from_user.username),
     )
     await alerts.notify_new_lead(
         message.bot,

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -268,7 +268,7 @@ async def callback_check_sub(call: types.CallbackQuery, state: FSMContext) -> No
         )
         await call.message.answer(
             "Дополнительные опции находятся на клавиатуре ниже.",
-            reply_markup=kb_main_menu(call.from_user.id),
+            reply_markup=kb_main_menu(call.from_user.id, call.from_user.username),
         )
         data = await state.get_data()
         autostart = data.get("lottery_autostart") if isinstance(data, dict) else None
@@ -314,7 +314,14 @@ async def _send_coupon(message: types.Message, code: str, campaign: str) -> None
         "• Действует до дедлайна кампании.\n\n"
         "Оставьте контакт, чтобы получить напоминание и инструкции."
     )
-    await message.answer(text, reply_markup=kb_after_coupon(campaign, message.from_user.id))
+    await message.answer(
+        text,
+        reply_markup=kb_after_coupon(
+            campaign,
+            message.from_user.id,
+            message.from_user.username,
+        ),
+    )
 
 
 async def issue_coupon(

--- a/app/keyboards/common.py
+++ b/app/keyboards/common.py
@@ -28,17 +28,21 @@ def kb_get_gift(campaign: str) -> InlineKeyboardMarkup:
     return kb
 
 
-def kb_main_menu(user_id: int | None = None) -> ReplyKeyboardMarkup:
+def kb_main_menu(user_id: int | None = None, username: str | None = None) -> ReplyKeyboardMarkup:
     kb = ReplyKeyboardMarkup(resize_keyboard=True)
     kb.add(KeyboardButton(text="📞 Оставить контакт"))
     kb.add(KeyboardButton(text="🥐 Производственный интенсив"))
-    if is_admin_user(user_id):
+    if is_admin_user(user_id, username):
         kb.add(KeyboardButton(text="Админ-панель"))
     return kb
 
 
-def kb_after_coupon(campaign: str, user_id: int | None = None) -> ReplyKeyboardMarkup:
-    return kb_main_menu(user_id=user_id)
+def kb_after_coupon(
+    campaign: str,
+    user_id: int | None = None,
+    username: str | None = None,
+) -> ReplyKeyboardMarkup:
+    return kb_main_menu(user_id=user_id, username=username)
 
 
 def kb_send_contact() -> ReplyKeyboardMarkup:


### PR DESCRIPTION
### Motivation
- The admin panel button and commands were only recognized by numeric chat IDs, so admins specified by Telegram username in `ADMIN_CHAT_ID` could not access the admin UI.  
- Allow listing admin usernames in `ADMIN_CHAT_ID` so the admin panel is shown and commands work for username-based admins as well.

### Description
- Added parsing of usernames from `ADMIN_CHAT_ID` into a new `Settings.admin_usernames` cached property and filtered numeric IDs as before in `Settings.admin_chat_ids` (`app/config.py`).
- Extended `is_admin_user` to accept an optional `username` parameter and to return true if either the numeric `user_id` or the normalized username is present in settings (`app/config.py`).
- Propagated `message.from_user.username` to keyboard and admin-check call sites so the main menu shows the "Админ-панель" button for username-based admins, by updating `kb_main_menu`/`kb_after_coupon` signature and callers in `app/keyboards/common.py`, `app/handlers/start.py`, and `app/handlers/contacts.py`.
- Updated all admin checks in `app/handlers/admin.py` to pass the username to `is_admin_user`, and documented username support in `README.md`.

### Testing
- Ran `python -m compileall app` to ensure code compiles and there are no syntax errors; the compile check passed.  
- No automated unit tests were present in the repository to run; changes were limited to parsing and argument passing and validated via static compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69789ff57ec08320a778abeec53d3fbc)