### PR TITLE
Fix imports: replace is_admin with is_admin_user

### DIFF
--- a/app/handlers/contacts.py
+++ b/app/handlers/contacts.py
@@ -6,7 +6,7 @@ import logging
 from aiogram import Dispatcher, types
 from aiogram.dispatcher import FSMContext
 
-from app.config import get_settings, is_admin
+from app.config import get_settings, is_admin_user
 from app.handlers import intensive as intensive_handlers
 from app.keyboards.common import kb_main_menu, kb_send_contact
 from app.services import alerts, phone, reminders, sheets, stats

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -7,7 +7,7 @@ from html import escape
 from aiogram import Dispatcher, types
 from aiogram.dispatcher import FSMContext
 
-from app.config import get_settings, is_admin
+from app.config import get_settings, is_admin_user
 from app.keyboards.common import (
     kb_after_coupon,
     kb_check_sub,

--- a/app/services/reminders.py
+++ b/app/services/reminders.py
@@ -11,7 +11,7 @@ from aiogram import Bot
 from aiogram.utils.exceptions import BotBlocked, ChatNotFound, RetryAfter, TelegramAPIError
 from zoneinfo import ZoneInfo
 
-from app.config import get_settings, is_admin
+from app.config import get_settings, is_admin_user
 from app.keyboards.common import kb_after_coupon
 from app.services import coupons, stats
 from app.utils import safe_text


### PR DESCRIPTION
Update all imports to use is_admin_user instead of is_admin:
- app/handlers/contacts.py
- app/handlers/start.py
- app/services/reminders.py

This matches the refactored function name in config.py that now supports checking both user_id and username.