### PR TITLE
Fix: import logging module in config.py

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 from functools import cached_property, lru_cache
 from typing import Any, Dict
 


### PR DESCRIPTION
NameError: name 'logging' is not defined was causing is_admin_user() to crash and preventing admin panel from working.