### PR TITLE
Fix admin buttons: add state parameter to callback handlers

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -141,8 +141,8 @@ def register(dp: Dispatcher) -> None:
     dp.register_message_handler(cmd_admin, commands=["admin"], state="*")
     dp.register_message_handler(cmd_admin, lambda message: message.text == "Админ-панель", state="*")
     dp.register_message_handler(cmd_cancel, commands=["cancel"], state="*")
-    dp.register_callback_query_handler(callback_admin_report, lambda c: c.data == "admin_report")
-    dp.register_callback_query_handler(callback_admin_add_coupon, lambda c: c.data == "admin_add_coupon")
+    dp.register_callback_query_handler(callback_admin_report, lambda c: c.data == "admin_report", state="*")
+    dp.register_callback_query_handler(callback_admin_add_coupon, lambda c: c.data == "admin_add_coupon", state="*")
     dp.register_message_handler(
         message_admin_coupon_code,
         state=AdminCouponStates.waiting_code,


### PR DESCRIPTION
Add state='*' to callback handler registrations:
- callback_admin_report
- callback_admin_add_coupon

This fixes AttributeError: 'NoneType' object has no attribute 'current_state' when clicking admin panel buttons.