### PR TITLE
Fix webhook FSM state handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,8 +41,9 @@ async def tg_webhook(request: Request) -> JSONResponse:
         raise HTTPException(status_code=403, detail="Forbidden")
     data = await request.json()
     update = types.Update(**data)
-    # Set bot instance in context for webhook mode
+    # Set bot/dispatcher instances in context for webhook mode
     Bot.set_current(bot)
+    Dispatcher.set_current(dp)
     await dp.process_update(update)
     return JSONResponse({"ok": True})
 


### PR DESCRIPTION
### Motivation
- Modified `app/main.py` in the `tg_webhook` handler to address FSM failures (logs showed `AttributeError: 'NoneType' object has no attribute 'current_state'` when admin callback handlers called `Dispatcher.get_current()`), so webhook updates have both bot and dispatcher context set.

### Description
- Added `Dispatcher.set_current(dp)` before calling `dp.process_update(update)` in `tg_webhook` and updated the comment to reflect that both bot and dispatcher are set.

### Testing
- Ran `python -m compileall app` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f49dc0f883208d09e0c5e85fface)